### PR TITLE
Refactored line numbering

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -6,10 +6,16 @@ function getNewLines(str) {
   return str.match(newLineRegex);
 }
 
+function getEmWidthOfNumber(num) {
+  const len = num.toString().length;
+  return `${len}em`;
+}
+
 function createLineElement({
   children,
   lineNumber,
   lineNumberStyle,
+  largestLineNumber,
   lineProps,
   className = []
 }) {
@@ -28,6 +34,7 @@ function createLineElement({
     // minimally necessary styling for line numbers
     const defaultLineNumberStyle = {
       display: 'inline-block',
+      minWidth: getEmWidthOfNumber(largestLineNumber),
       paddingRight: '1em',
       textAlign: 'right',
       userSelect: 'none'
@@ -87,6 +94,7 @@ function wrapLinesInSpan(
   lineProps,
   showLineNumbers,
   startingLineNumber,
+  largestLineNumber,
   lineNumberStyle
 ) {
   const tree = flattenCodeTree(codeTree.value);
@@ -115,6 +123,7 @@ function wrapLinesInSpan(
               children,
               lineNumber,
               lineNumberStyle,
+              largestLineNumber,
               lineProps
             })
           );
@@ -136,6 +145,7 @@ function wrapLinesInSpan(
                 children: [newChild],
                 lineNumber,
                 lineNumberStyle,
+                largestLineNumber,
                 lineProps,
                 className: node.properties.className
               })
@@ -147,6 +157,7 @@ function wrapLinesInSpan(
               children: [newChild],
               lineNumber,
               lineNumberStyle,
+              largestLineNumber,
               lineProps,
               className: node.properties.className
             })
@@ -165,6 +176,7 @@ function wrapLinesInSpan(
           children,
           lineNumber: newTree.length + startingLineNumber,
           lineNumberStyle,
+          largestLineNumber,
           lineProps
         })
       );
@@ -260,12 +272,16 @@ export default function(defaultAstGenerator, defaultStyle) {
       codeTree.value = defaultCodeValue;
     }
 
+    // determine largest line number so that we can force minWidth on all linenumber elements
+    const largestLineNumber = codeTree.value.length + startingLineNumber;
+
     const tree = wrapLines
       ? wrapLinesInSpan(
           codeTree,
           lineProps,
           showLineNumbers,
           startingLineNumber,
+          largestLineNumber,
           lineNumberStyle
         )
       : codeTree.value;

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -28,7 +28,7 @@ function createLineElement({
         className: ['react-syntax-highlighter-line-number'],
         style:
           typeof lineNumberStyle === 'function'
-            ? numberStyle(lineNumberStyle)
+            ? lineNumberStyle(lineNumber)
             : lineNumberStyle
       },
       children: [

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -275,16 +275,17 @@ export default function(defaultAstGenerator, defaultStyle) {
     // determine largest line number so that we can force minWidth on all linenumber elements
     const largestLineNumber = codeTree.value.length + startingLineNumber;
 
-    const tree = wrapLines
-      ? wrapLinesInSpan(
-          codeTree,
-          lineProps,
-          showLineNumbers,
-          startingLineNumber,
-          largestLineNumber,
-          lineNumberStyle
-        )
-      : codeTree.value;
+    const tree =
+      wrapLines || showLineNumbers
+        ? wrapLinesInSpan(
+            codeTree,
+            lineProps,
+            showLineNumbers,
+            startingLineNumber,
+            largestLineNumber,
+            lineNumberStyle
+          )
+        : codeTree.value;
 
     return (
       <PreTag {...preProps}>

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -6,39 +6,6 @@ function getNewLines(str) {
   return str.match(newLineRegex);
 }
 
-function getLineNumbers({ lines, startingLineNumber, style }) {
-  return lines.map((_, i) => {
-    const number = i + startingLineNumber;
-    return (
-      <span
-        key={`line-${i}`}
-        className="react-syntax-highlighter-line-number"
-        style={typeof style === 'function' ? style(number) : style}
-      >
-        {`${number}\n`}
-      </span>
-    );
-  });
-}
-
-function LineNumbers({
-  codeString,
-  codeStyle,
-  containerStyle = { float: 'left', paddingRight: '10px' },
-  numberStyle = {},
-  startingLineNumber
-}) {
-  return (
-    <code style={Object.assign({}, codeStyle, containerStyle)}>
-      {getLineNumbers({
-        lines: codeString.replace(/\n$/, '').split('\n'),
-        style: numberStyle,
-        startingLineNumber
-      })}
-    </code>
-  );
-}
-
 function createLineElement({
   children,
   lineNumber,
@@ -244,16 +211,6 @@ export default function(defaultAstGenerator, defaultStyle) {
   }) {
     astGenerator = astGenerator || defaultAstGenerator;
 
-    const lineNumbers = showLineNumbers ? (
-      <LineNumbers
-        containerStyle={lineNumberContainerStyle}
-        codeStyle={codeTagProps.style || {}}
-        numberStyle={lineNumberStyle}
-        startingLineNumber={startingLineNumber}
-        codeString={code}
-      />
-    ) : null;
-
     const defaultPreStyle = style.hljs ||
       style['pre[class*="language-"]'] || { backgroundColor: '#fff' };
     const preProps = useInlineStyles
@@ -265,7 +222,6 @@ export default function(defaultAstGenerator, defaultStyle) {
     if (!astGenerator) {
       return (
         <PreTag {...preProps}>
-          {lineNumbers}
           <CodeTag {...codeTagProps}>{code}</CodeTag>
         </PreTag>
       );
@@ -300,7 +256,6 @@ export default function(defaultAstGenerator, defaultStyle) {
 
     return (
       <PreTag {...preProps}>
-        {lineNumbers}
         <CodeTag {...codeTagProps}>
           {renderer({ rows: tree, stylesheet: style, useInlineStyles })}
         </CodeTag>

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -76,7 +76,13 @@ function flattenCodeTree(tree, className = [], newTree = []) {
   return newTree;
 }
 
-function wrapLinesInSpan(codeTree, lineProps) {
+function wrapLinesInSpan(
+  codeTree,
+  lineProps,
+  showLineNumbers,
+  startingLineNumber,
+  lineNumberStyle
+) {
   const tree = flattenCodeTree(codeTree.value);
   const newTree = [];
   let lastLineBreakIndex = -1;
@@ -249,7 +255,13 @@ export default function(defaultAstGenerator, defaultStyle) {
     }
 
     const tree = wrapLines
-      ? wrapLinesInSpan(codeTree, lineProps)
+      ? wrapLinesInSpan(
+          codeTree,
+          lineProps,
+          showLineNumbers,
+          startingLineNumber,
+          lineNumberStyle
+        )
       : codeTree.value;
 
     return (

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -37,7 +37,11 @@ function createLineElement({
       tagName: 'span',
       properties: {
         key: `line-number--${lineNumber}`,
-        className: ['react-syntax-highlighter-line-number'],
+        className: [
+          'comment',
+          'linenumber',
+          'react-syntax-highlighter-line-number'
+        ],
         style: {
           ...defaultLineNumberStyle,
           ...customLineNumberStyle

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -94,7 +94,8 @@ function wrapLinesInSpan(
     if (newLines) {
       const splitValue = value.split('\n');
       splitValue.forEach((text, i) => {
-        const lineNumber = newTree.length + 1;
+        const lineNumber =
+          showLineNumbers && newTree.length + startingLineNumber;
         const newChild = { type: 'text', value: `${text}\n` };
         if (i === 0) {
           const children = tree.slice(lastLineBreakIndex + 1, index).concat(
@@ -147,7 +148,7 @@ function wrapLinesInSpan(
       newTree.push(
         createLineElement({
           children,
-          lineNumber: newTree.length + 1,
+          lineNumber: newTree.length + startingLineNumber,
           lineProps
         })
       );

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -51,6 +51,28 @@ function createLineElement({
   properties.className = properties.className
     ? className.concat(properties.className)
     : className;
+
+  if (lineNumber) {
+    children.unshift({
+      type: 'element',
+      tagName: 'span',
+      properties: {
+        key: `line-number--${lineNumber}`,
+        className: ['react-syntax-highlighter-line-number'],
+        style:
+          typeof lineNumberStyle === 'function'
+            ? numberStyle(lineNumberStyle)
+            : lineNumberStyle
+      },
+      children: [
+        {
+          type: 'text',
+          value: lineNumber
+        }
+      ]
+    });
+  }
+
   return {
     type: 'element',
     tagName: 'span',

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -20,16 +20,28 @@ function createLineElement({
     : className;
 
   if (lineNumber) {
+    const customLineNumberStyle =
+      typeof lineNumberStyle === 'function'
+        ? lineNumberStyle(lineNumber)
+        : lineNumberStyle;
+
+    // minimally necessary styling for line numbers
+    const defaultLineNumberStyle = {
+      display: 'inline-block',
+      paddingRight: '1em',
+      textAlign: 'right',
+      userSelect: 'none'
+    };
     children.unshift({
       type: 'element',
       tagName: 'span',
       properties: {
         key: `line-number--${lineNumber}`,
         className: ['react-syntax-highlighter-line-number'],
-        style:
-          typeof lineNumberStyle === 'function'
-            ? lineNumberStyle(lineNumber)
-            : lineNumberStyle
+        style: {
+          ...defaultLineNumberStyle,
+          ...customLineNumberStyle
+        }
       },
       children: [
         {

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -42,6 +42,7 @@ function LineNumbers({
 function createLineElement({
   children,
   lineNumber,
+  lineNumberStyle,
   lineProps,
   className = []
 }) {
@@ -104,7 +105,14 @@ function wrapLinesInSpan(
               className: node.properties.className
             })
           );
-          newTree.push(createLineElement({ children, lineNumber, lineProps }));
+          newTree.push(
+            createLineElement({
+              children,
+              lineNumber,
+              lineNumberStyle,
+              lineProps
+            })
+          );
         } else if (i === splitValue.length - 1) {
           const stringChild =
             tree[index + 1] &&
@@ -122,6 +130,7 @@ function wrapLinesInSpan(
               createLineElement({
                 children: [newChild],
                 lineNumber,
+                lineNumberStyle,
                 lineProps,
                 className: node.properties.className
               })
@@ -132,6 +141,7 @@ function wrapLinesInSpan(
             createLineElement({
               children: [newChild],
               lineNumber,
+              lineNumberStyle,
               lineProps,
               className: node.properties.className
             })
@@ -149,6 +159,7 @@ function wrapLinesInSpan(
         createLineElement({
           children,
           lineNumber: newTree.length + startingLineNumber,
+          lineNumberStyle,
           lineProps
         })
       );
@@ -199,7 +210,7 @@ export default function(defaultAstGenerator, defaultStyle) {
     showLineNumbers = false,
     startingLineNumber = 1,
     lineNumberContainerStyle,
-    lineNumberStyle,
+    lineNumberStyle = {},
     wrapLines,
     lineProps = {},
     renderer,

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -6,6 +6,39 @@ function getNewLines(str) {
   return str.match(newLineRegex);
 }
 
+function getAllLineNumbers({ lines, startingLineNumber, style }) {
+  return lines.map((_, i) => {
+    const number = i + startingLineNumber;
+    return (
+      <span
+        key={`line-${i}`}
+        className="react-syntax-highlighter-line-number"
+        style={typeof style === 'function' ? style(number) : style}
+      >
+        {`${number}\n`}
+      </span>
+    );
+  });
+}
+
+function AllLineNumbers({
+  codeString,
+  codeStyle,
+  containerStyle = { float: 'left', paddingRight: '10px' },
+  numberStyle = {},
+  startingLineNumber
+}) {
+  return (
+    <code style={Object.assign({}, codeStyle, containerStyle)}>
+      {getAllLineNumbers({
+        lines: codeString.replace(/\n$/, '').split('\n'),
+        style: numberStyle,
+        startingLineNumber
+      })}
+    </code>
+  );
+}
+
 function getEmWidthOfNumber(num) {
   const len = num.toString().length;
   return `${len}em`;
@@ -239,6 +272,16 @@ export default function(defaultAstGenerator, defaultStyle) {
   }) {
     astGenerator = astGenerator || defaultAstGenerator;
 
+    const allLineNumbers = showLineNumbers ? (
+      <AllLineNumbers
+        containerStyle={lineNumberContainerStyle}
+        codeStyle={codeTagProps.style || {}}
+        numberStyle={lineNumberStyle}
+        startingLineNumber={startingLineNumber}
+        codeString={code}
+      />
+    ) : null;
+
     const defaultPreStyle = style.hljs ||
       style['pre[class*="language-"]'] || { backgroundColor: '#fff' };
     const preProps = useInlineStyles
@@ -250,6 +293,7 @@ export default function(defaultAstGenerator, defaultStyle) {
     if (!astGenerator) {
       return (
         <PreTag {...preProps}>
+          {allLineNumbers}
           <CodeTag {...codeTagProps}>{code}</CodeTag>
         </PreTag>
       );

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -319,21 +319,21 @@ export default function(defaultAstGenerator, defaultStyle) {
     // determine largest line number so that we can force minWidth on all linenumber elements
     const largestLineNumber = codeTree.value.length + startingLineNumber;
 
-    const tree =
-      wrapLines || showLineNumbers
-        ? wrapLinesInSpan(
-            codeTree,
-            lineProps,
-            showLineNumbers,
-            startingLineNumber,
-            largestLineNumber,
-            lineNumberStyle
-          )
-        : codeTree.value;
+    const tree = wrapLines
+      ? wrapLinesInSpan(
+          codeTree,
+          lineProps,
+          showLineNumbers,
+          startingLineNumber,
+          largestLineNumber,
+          lineNumberStyle
+        )
+      : codeTree.value;
 
     return (
       <PreTag {...preProps}>
         <CodeTag {...codeTagProps}>
+          {!wrapLines && allLineNumbers}
           {renderer({ rows: tree, stylesheet: style, useInlineStyles })}
         </CodeTag>
       </PreTag>


### PR DESCRIPTION
This refactor provides line numbering that's compatible with `react-syntax-highlighter-virtualized-renderer`, which can't properly render a separate `<code>` block containing line numbers.

Line numbers are now inserted as child nodes of each code line, but have some default styling applied in order to keep them from being selected or interfering with code rendering.

To do:

- [ ] syntax tokenization is getting disrupted, and highlighting isn't being applied correctly as a result
- [ ] update tests